### PR TITLE
Fix loop over byvars in `add_ards`

### DIFF
--- a/R/ards.R
+++ b/R/ards.R
@@ -297,7 +297,7 @@ add_ards <- function(data, statvars, statdesc = NULL,
 
     # Populate By variables and values
     if (!is.null(byvars)) {
-      for (j in seq_along(length(byvars))) {
+      for (j in seq_len(length(byvars))) {
         ret[[paste0("byvar", j)]] <- byvars[[j]]
 
         if (!is.null(data[[byvars[[j]]]]))


### PR DESCRIPTION
**Problem:** Line 300 uses `seq_along(length(byvars))` which returns `1` regardless of how many by-variables are specified. This causes the loop to only process the first by-variable.
**Solution:** Replace with `seq_len(length(byvars))` as used in line 259.